### PR TITLE
Improve GitHub trending script with offline fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # my_learn
+
+This repository includes a script to fetch the top trending projects on GitHub
+for the current day and display their descriptions translated to Chinese. When
+network access is unavailable, the script falls back to a built-in list of
+example repositories so it can run without errors.
+
+## Requirements
+
+The script `github_trending.py` uses Python 3. It optionally depends on
+`googletrans` for translation support. If this dependency or network access is
+not available, the script outputs the built-in Chinese descriptions for the
+offline list or the original English descriptions for live data.
+
+Install dependencies (when network access is available):
+
+```bash
+pip install googletrans==4.0.0-rc1
+```
+
+## Usage
+
+Run the script directly with Python:
+
+```bash
+python github_trending.py
+```
+
+The script will print the top ten trending repositories and their descriptions
+in Chinese (or English if translation is not possible).
+
+If the script cannot access GitHub, the built-in offline list will be used.

--- a/github_trending.py
+++ b/github_trending.py
@@ -1,0 +1,119 @@
+import urllib.request
+import urllib.error
+import re
+import html
+
+
+OFFLINE_TRENDING = [
+    {
+        "repo": "EbookFoundation/free-programming-books",
+        "desc": "Free programming books",
+        "desc_cn": "免费编程书籍列表",
+    },
+    {
+        "repo": "996icu/996.ICU",
+        "desc": "Repo for the 996.ICU movement",
+        "desc_cn": "关于996.ICU运动的仓库",
+    },
+    {
+        "repo": "microsoft/vscode",
+        "desc": "Visual Studio Code",
+        "desc_cn": "微软的开源代码编辑器",
+    },
+    {
+        "repo": "torvalds/linux",
+        "desc": "Linux kernel source tree",
+        "desc_cn": "Linux内核源代码",
+    },
+    {
+        "repo": "facebook/react",
+        "desc": "A JavaScript library for building user interfaces",
+        "desc_cn": "用于构建用户界面的JavaScript库",
+    },
+    {
+        "repo": "tensorflow/tensorflow",
+        "desc": "An end-to-end open source machine learning platform",
+        "desc_cn": "端到端的开源机器学习平台",
+    },
+    {
+        "repo": "kubernetes/kubernetes",
+        "desc": "Production-Grade Container Scheduling and Management",
+        "desc_cn": "生产级的容器编排和管理平台",
+    },
+    {
+        "repo": "donnemartin/system-design-primer",
+        "desc": "Learn how to design large-scale systems",
+        "desc_cn": "学习如何设计大规模系统",
+    },
+    {
+        "repo": "public-apis/public-apis",
+        "desc": "A collective list of free APIs",
+        "desc_cn": "免费API的集合列表",
+    },
+    {
+        "repo": "psf/requests",
+        "desc": "A simple, yet elegant, HTTP library",
+        "desc_cn": "简单优雅的HTTP库",
+    },
+]
+
+
+def fetch_trending():
+    """Fetch GitHub trending repositories for today.
+
+    If network access fails, return a predefined offline list.
+    """
+    url = "https://github.com/trending?since=daily"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            html_data = resp.read().decode("utf-8")
+        return parse_trending(html_data)
+    except Exception as e:
+        print(f"Network unavailable, using offline data: {e}")
+        return OFFLINE_TRENDING
+
+
+def parse_trending(html_data):
+    """Parse trending repository info from HTML."""
+    repo_pattern = re.compile(
+        r'<h2[^>]*>\s*<a href="/(.*?)"[^>]*>.*?</a>.*?</h2>.*?<p[^>]*>(.*?)</p>',
+        re.S,
+    )
+    results = re.findall(repo_pattern, html_data)
+    trending = []
+    for repo, desc in results[:10]:
+        repo = html.unescape(repo.strip())
+        desc = re.sub(r'<.*?>', '', desc)
+        desc = html.unescape(desc.strip())
+        trending.append({"repo": repo, "desc": desc})
+    return trending
+
+
+def translate_to_chinese(text):
+    """Translate text to Chinese using googletrans if available."""
+    try:
+        from googletrans import Translator
+    except Exception:
+        return text  # Fallback: return original text
+    translator = Translator()
+    try:
+        return translator.translate(text, dest="zh-cn").text
+    except Exception:
+        return text
+
+
+def main():
+    try:
+        trending = fetch_trending()
+    except Exception as e:
+        print(f"Error fetching trending data: {e}")
+        return
+    for idx, item in enumerate(trending, 1):
+        repo = item.get("repo")
+        desc = item.get("desc", "")
+        desc_cn = item.get("desc_cn") or translate_to_chinese(desc)
+        print(f"{idx}. {repo} - {desc_cn}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- handle network failures by providing an offline list of repositories
- adjust parsing logic to return dictionaries
- use predefined Chinese descriptions when offline
- clarify offline mode in the README

## Testing
- `python github_trending.py`


------
https://chatgpt.com/codex/tasks/task_e_684d823742108330a6974a77cdcb9dfc